### PR TITLE
change package installs to ensure_packages()

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -160,7 +160,7 @@
 #   are permitted to access most data in NetBox (excluding secrets) but not make any changes.
 #
 # @param metrics_enabled
-#   Setting this to true exposes Prometheus metrics at /metrics. 
+#   Setting this to true exposes Prometheus metrics at /metrics.
 #   See the Promethues Metrics documentation for more details:
 #   https://netbox.readthedocs.io/en/stable/additional-features/prometheus-metrics/)
 #
@@ -279,7 +279,7 @@ class netbox (
   String $short_datetime_format = 'Y-m-d H:i',
 ) {
 
-  Class['netbox::database'] -> Class['netbox::redis'] -> Class['netbox::install'] -> Class['netbox::config'] ~> Class['netbox::service']
+  Class['netbox::install'] -> Class['netbox::config'] ~> Class['netbox::service']
 
   if $handle_database {
     class { 'netbox::database':
@@ -289,11 +289,17 @@ class netbox (
       database_encoding => $database_encoding,
       database_locale   => $database_locale,
     }
+    if $handle_redis {
+      Class['netbox::database'] -> Class['netbox::redis']
+    } else {
+      Class['netbox::database'] -> Class['netbox::install']
+    }
   }
 
   if $handle_redis {
     class { 'netbox::redis':
     }
+    Class['netbox::redis'] -> Class['netbox::install']
   }
 
   class { 'netbox::install':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -97,10 +97,10 @@ class netbox::install (
 
   $ldap_packages = [openldap-devel]
 
-  package { $packages: ensure => 'installed' }
+  ensure_packages($packages)
 
   if $include_ldap {
-    package { $ldap_packages: ensure => 'installed' }
+    ensure_packages($ldap_packages)
   }
 
   user { $user:

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -33,6 +33,14 @@ describe 'netbox::config' do
               default_timeout: 300,
               ssl: false,
             },
+            tasks: {
+              host: 'localhost',
+              port: 6379,
+              password: '',
+              database: 0,
+              default_timeout: 300,
+              ssl: 'False',
+            },
           },
           email_options: {
             server: 'smtp.example.com',

--- a/spec/classes/database_spec.rb
+++ b/spec/classes/database_spec.rb
@@ -9,6 +9,8 @@ describe 'netbox::database' do
           database_name: 'testdb',
           database_user: 'testdbuser',
           database_password: 'testdbpass',
+          database_encoding: 'UTF-8',
+          database_locale: 'en_US.UTF-8',
         }
       end
 


### PR DESCRIPTION
Change package installs to ensure_packages(), so class can work with other manifests without resource dupes.

Also fixed several tests that were failing.

Also fixed some dependency issues where if you manage redis or database elsewhere, the catalog will not compile.