### PR TITLE
add stdlib dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,10 @@
   "project_page": "https://github.com/anderssh/ash-netbox",
   "issues_url": "https://github.com/anderssh/ash-netbox/issues",
   "dependencies": [
-
+    {
+      "name": "puppetlabs-stdlib",
+      "version_requirement": ">= 1.0.0"
+    }
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
This adds "puppetlabs-stdlib" as a dependency in metadata.json.

I don't remember the exact error I got without this change. Apologies if this is a spurious MR. I thought I'd push it just in case...