### PR TITLE
add configurable REPORTS_ROOT setting

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -13,6 +13,10 @@
 # @param install_root
 #   The directory where the netbox installation is unpacked
 #
+# @param reports_root
+#   The file path to the location where custom reports will be kept.
+#   By default, this is the netbox/reports/ directory within the base NetBox installation path.
+#
 # @param allowed_hosts
 #   Array of valid fully-qualified domain names (FQDNs) for the NetBox server. NetBox will not permit write
 #   access to the server via any other hostnames. The first FQDN in the list will be treated as the preferred name.
@@ -138,6 +142,7 @@ class netbox::config (
   String $user,
   String $group,
   Stdlib::Absolutepath $install_root,
+  Optional[Stdlib::Absolutepath] $reports_root,
   Array[Stdlib::Host] $allowed_hosts,
   String $database_name,
   String $database_user,
@@ -202,6 +207,7 @@ class netbox::config (
       'database_host'           => $database_host,
       'database_port'           => $database_port,
       'database_conn_max_age'   => $database_conn_max_age,
+      'reports_root'            => $reports_root,
       'redis_options'           => $redis_options,
       'email_options'           => $email_options,
       'secret_key'              => $secret_key,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,10 @@
 # @param install_root
 #   The directory where the netbox installation is unpacked
 #
+# @param reports_root
+#   The directory where custom reports will be kept.
+#   By default, this is the netbox/reports/ directory within the base NetBox installation path.
+#
 # @param handle_database
 #   Should the PostgreSQL database be handled by this module.
 #
@@ -229,6 +233,7 @@ class netbox (
   String $version = '2.10.1',
   String $download_url = 'https://github.com/netbox-community/netbox/archive/v2.10.1.tar.gz',
   String $download_checksum = 'b827c520e4c82842e426a5f9ad2d914d1728a3671e304d5f25eb06392c24866c',
+  Optional[Stdlib::Absolutepath] $reports_root = undef,
   Stdlib::Absolutepath $download_tmp_dir = '/var/tmp',
   String $user = 'netbox',
   String $group = 'netbox',
@@ -350,6 +355,7 @@ class netbox (
     user                    => $user,
     group                   => $group,
     install_root            => $install_root,
+    reports_root            => $reports_root,
     allowed_hosts           => $allowed_hosts,
     database_name           => $database_name,
     database_user           => $database_user,

--- a/templates/configuration.py.epp
+++ b/templates/configuration.py.epp
@@ -8,6 +8,7 @@
   Integer $database_conn_max_age,
   Hash $redis_options,
   Hash $email_options,
+  Optional[Stdlib::Absolutepath] $reports_root,
   String $secret_key,
   String $banner_top,
   String $banner_bottom,
@@ -233,9 +234,11 @@ PREFER_IPV4 = True
 PREFER_IPV4 = False
 <% } -%>
 
+<% unless $reports_root =~ Undef { -%>
 # The file path where custom reports will be stored. A trailing slash is not needed. Note that the default value of
 # this setting is derived from the installed location.
-# REPORTS_ROOT = '/opt/netbox/netbox/reports'
+REPORTS_ROOT = '<%= $reports_root %>'
+<% } -%>
 
 # The file path where custom scripts will be stored. A trailing slash is not needed. Note that the default value of
 # this setting is derived from the installed location.


### PR DESCRIPTION
Adds a `reports_root` parameter and setting in configuration.py.