### PR TITLE
Bump python version 3.6 to 3.9

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -81,8 +81,8 @@ class netbox::install (
 
   $packages =[
     gcc,
-    python36,
-    python36-devel,
+    python39,
+    python39-devel,
     libxml2-devel,
     libxslt-devel,
     libffi-devel,


### PR DESCRIPTION
Upgrade python version to 3.9 but python 3.6 is no longer supported with NetBox versions above v3.