### PR TITLE
Support NetBox v3

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -248,9 +248,16 @@ class netbox::config (
     require => File[$config_file],
     notify  => Exec['collect static files'],
   }
+  file { 'static_folder':
+    ensure => 'directory',
+    path   => "${software_directory}/netbox/static",
+    owner  => $user,
+    group  => $group,
+    mode   => '0644',
+  }
   exec { 'collect static files':
     command     => "${venv_dir}/bin/python3 netbox/manage.py collectstatic --no-input",
-    require     => File[$config_file],
+    require     => [ File[$config_file], File['static_folder'] ],
     refreshonly => true,
   }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,6 +2,11 @@
 #
 # Configures Netbox and gunicorn, and load the database schema.
 #
+# @param version
+#   The version of Netbox. This must match the version in the
+#   tarball. This is used for managing files, directories and paths in
+#   the service.
+#
 # @param user
 #   The user owning the Netbox installation files, and running the
 #   service.
@@ -135,6 +140,7 @@
 # @example
 #   include netbox::config
 class netbox::config (
+  String $version,
   String $user,
   String $group,
   Stdlib::Absolutepath $install_root,
@@ -195,6 +201,7 @@ class netbox::config (
 
   file { $config_file:
     content      => epp('netbox/configuration.py.epp', {
+      'version'                 => $version,
       'allowed_hosts'           => $allowed_hosts,
       'database_name'           => $database_name,
       'database_user'           => $database_user,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -347,6 +347,7 @@ class netbox (
   }
 
   class { 'netbox::config':
+    version                 => $version,
     user                    => $user,
     group                   => $group,
     install_root            => $install_root,

--- a/templates/configuration.py.epp
+++ b/templates/configuration.py.epp
@@ -1,4 +1,5 @@
 <% | 
+  String $version,
   Array[Stdlib::Host] $allowed_hosts,
   String $database_name,
   String $database_user,
@@ -115,8 +116,10 @@ BANNER_LOGIN = '<%= $banner_login %>'
 # BASE_PATH = 'netbox/'
 BASE_PATH = '<%= $base_path %>'
 
+<% if versioncmp(split($version, '[.]')[0], '3') < 0 { -%>
 # Cache timeout in seconds. Set to 0 to dissable caching. Defaults to 900 (15 minutes)
 CACHE_TIMEOUT = 900
+<% } -%>
 
 # Maximum number of days to retain logged changes. Set to 0 to retain changes indefinitely. (Default: 90)
 CHANGELOG_RETENTION = 90


### PR DESCRIPTION
1. Create netbox/static folder before collecting static files otherwise tere is a permission error to create this folder as netbox user.
2. UserWarning: The CACHE_TIMEOUT configuration parameter was removed in v3.0.0 and no longer has any effect.