### PR TITLE
Implement custom configuration blocks

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -169,6 +169,7 @@ class netbox::config (
   String $short_time_format,
   String $datetime_format,
   String $short_datetime_format,
+  Array[String] $custom_configuration = [],
 ) {
   $should_create_superuser = false;
   $software_directory = "${install_root}/netbox"
@@ -226,6 +227,7 @@ class netbox::config (
       'short_time_format'       => $short_time_format,
       'datetime_format'         => $datetime_format,
       'short_datetime_format'   => $short_datetime_format,
+      'custom_configuration'    => $custom_configuration,
     }),
     owner        => $user,
     group        => $group,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -212,18 +212,30 @@
 #   Date/time formatting. See the following link for supported formats:
 #   https://docs.djangoproject.com/en/stable/ref/templates/builtins/#date
 #
+# @param custom_configuration
+#   An array of strings containing custom configuration blocks
+#   Make sure these are valid python
+#
 # @example Defaults
 #   class { 'netbox':
-#     secret_key => $my_secret_variable
+#     secret_key          => $my_secret_variable
 #   }
 #
 # @example Downloading from a different repository
 #   class { 'netbox':
-#     version           => 'x.y.z',
-#     download_url      => 'https://my.local.repo.example.com/netbox/netbox-x.y.z.tar.gz',
-#     download_checksum => 'abcde...',
+#     version             => 'x.y.z',
+#     download_url        => 'https://my.local.repo.example.com/netbox/netbox-x.y.z.tar.gz',
+#     download_checksum   => 'abcde...',
 #   }
 #
+# @example Using custom configuration entries
+# class { '::netbox':
+#   custom_configuration => [
+#     'SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL = "https://login.keycloak/auth",
+#     'SOCIAL_AUTH_KEYCLOAK_SECRET = "secret",
+#   ]
+# }
+
 class netbox (
   String $secret_key,
   String $version = '2.10.1',
@@ -277,6 +289,7 @@ class netbox (
   String $short_time_format = 'H:i:s',
   String $datetime_format = 'N j, Y g:i a',
   String $short_datetime_format = 'Y-m-d H:i',
+  Array[String] $custom_configuration = [],
 ) {
 
   Class['netbox::install'] -> Class['netbox::config'] ~> Class['netbox::service']
@@ -381,6 +394,7 @@ class netbox (
     short_time_format       => $short_time_format,
     datetime_format         => $datetime_format,
     short_datetime_format   => $short_datetime_format,
+    custom_configuration    => $custom_configuration,
   }
 
   class {'netbox::service':

--- a/templates/configuration.py.epp
+++ b/templates/configuration.py.epp
@@ -30,6 +30,7 @@
   String $short_time_format, 
   String $datetime_format,
   String $short_datetime_format,
+  Array[String] $custom_configuration,
   | -%>
 
 #########################
@@ -257,3 +258,6 @@ TIME_FORMAT = '<%= $time_format %>'
 SHORT_TIME_FORMAT = '<%= $short_time_format %>'
 DATETIME_FORMAT = '<%= $datetime_format %>'
 SHORT_DATETIME_FORMAT = '<%= $short_datetime_format %>'
+<% $custom_configuration.each|String $block| { -%>
+<%= $block %>
+<% } -%>


### PR DESCRIPTION
Fixes #13

Example:

```
class { '::netbox':
  version => '3.0.0',
  custom_configuration => [
    "SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL = ${openid_url}",
    "SOCIAL_AUTH_KEYCLOAK_SECRET = 'secret',
  ]
}
```